### PR TITLE
feat: add databricks options and contract tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore
+        run: dotnet restore EFCore.Databricks.sln
+      - name: Build
+        run: dotnet build EFCore.Databricks.sln --no-restore -c Release
+      - name: Test
+        run: dotnet test EFCore.Databricks.sln --no-build -c Release

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ obj/
 *.suo
 *.userosscache
 *.sln.docstates
+/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,13 @@
 
 /.vs/slnx.sqlite
 /.vs/databricks-ef-dataprovider
+
+# Build outputs
+bin/
+obj/
+
+# User-specific files
+*.user
+*.suo
+*.userosscache
+*.sln.docstates

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/EFCore.Databricks.sln
+++ b/EFCore.Databricks.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7DC213E6-44DF-45D2-83C2-948B143E522E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFCore.Databricks", "src\EFCore.Databricks\EFCore.Databricks.csproj", "{6859FDF5-E98D-47D1-9639-3C4C96A1A2BD}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{6A9CE3E3-0498-403C-A8BB-0C060881A748}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFCore.Databricks.Tests", "tests\EFCore.Databricks.Tests\EFCore.Databricks.Tests.csproj", "{2C7DB2BB-0232-4505-8E6C-22E2CC8F01AD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6859FDF5-E98D-47D1-9639-3C4C96A1A2BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6859FDF5-E98D-47D1-9639-3C4C96A1A2BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6859FDF5-E98D-47D1-9639-3C4C96A1A2BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6859FDF5-E98D-47D1-9639-3C4C96A1A2BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C7DB2BB-0232-4505-8E6C-22E2CC8F01AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C7DB2BB-0232-4505-8E6C-22E2CC8F01AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C7DB2BB-0232-4505-8E6C-22E2CC8F01AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C7DB2BB-0232-4505-8E6C-22E2CC8F01AD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{6859FDF5-E98D-47D1-9639-3C4C96A1A2BD} = {7DC213E6-44DF-45D2-83C2-948B143E522E}
+		{2C7DB2BB-0232-4505-8E6C-22E2CC8F01AD} = {6A9CE3E3-0498-403C-A8BB-0C060881A748}
+	EndGlobalSection
+EndGlobal

--- a/samples/GraphQL/README.md
+++ b/samples/GraphQL/README.md
@@ -1,0 +1,5 @@
+# GraphQL Sample
+
+This directory is reserved for a future sample demonstrating the
+Databricks EF Core provider together with a Hot Chocolate GraphQL
+server.

--- a/src/EFCore.Databricks/EFCore.Databricks.csproj
+++ b/src/EFCore.Databricks/EFCore.Databricks.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="System.Data.Odbc" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/EFCore.Databricks/EFCore.Databricks.csproj
+++ b/src/EFCore.Databricks/EFCore.Databricks.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/EFCore.Databricks/Extensions/DatabricksDbContextOptionsExtensions.cs
+++ b/src/EFCore.Databricks/Extensions/DatabricksDbContextOptionsExtensions.cs
@@ -31,7 +31,6 @@ namespace Microsoft.EntityFrameworkCore
             ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
 
             optionsBuilder.ConfigureWarnings(w => w.Default(WarningBehavior.Throw));
-            optionsBuilder.UseSqlite("Data Source=:memory:"); // TODO: replace with Databricks-specific provider
             optionsBuilder.ReplaceService<ISqlGenerationHelper, DatabricksSqlGenerationHelper>();
             optionsBuilder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
             return optionsBuilder;

--- a/src/EFCore.Databricks/Extensions/DatabricksDbContextOptionsExtensions.cs
+++ b/src/EFCore.Databricks/Extensions/DatabricksDbContextOptionsExtensions.cs
@@ -1,5 +1,5 @@
 using System;
-using Microsoft.EntityFrameworkCore;
+using EFCore.Databricks.Infrastructure;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 

--- a/src/EFCore.Databricks/Extensions/DatabricksDbContextOptionsExtensions.cs
+++ b/src/EFCore.Databricks/Extensions/DatabricksDbContextOptionsExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore
             ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
 
             optionsBuilder.ConfigureWarnings(w => w.Default(WarningBehavior.Throw));
-            optionsBuilder.UseSqlite("Data Source=:memory:");
+            optionsBuilder.UseSqlite("Data Source=:memory:"); // TODO: replace with Databricks-specific provider
             optionsBuilder.ReplaceService<ISqlGenerationHelper, DatabricksSqlGenerationHelper>();
             optionsBuilder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
             return optionsBuilder;

--- a/src/EFCore.Databricks/Extensions/DatabricksDbContextOptionsExtensions.cs
+++ b/src/EFCore.Databricks/Extensions/DatabricksDbContextOptionsExtensions.cs
@@ -1,0 +1,68 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// Provides helpers for configuring a <see cref="DbContext"/> to use the
+    /// Databricks provider.
+    /// </summary>
+    public static class DatabricksDbContextOptionsExtensions
+    {
+        /// <summary>
+        /// Configures the context to use the Databricks provider. The connection
+        /// string is resolved using the following precedence:
+        /// explicit <paramref name="connectionString"/> parameter,
+        /// environment variable <c>DATABRICKS_CONNECTION_STRING</c>, then
+        /// <c>DATABRICKS_DSN</c> combined with <c>DATABRICKS_TOKEN</c>.
+        /// </summary>
+        public static DbContextOptionsBuilder UseDatabricks(
+            this DbContextOptionsBuilder optionsBuilder,
+            string? connectionString = null)
+        {
+            var resolved = ResolveConnectionString(connectionString);
+
+            var extension = optionsBuilder.Options.FindExtension<DatabricksOptionsExtension>()
+                ?? new DatabricksOptionsExtension();
+            extension = extension.WithConnectionString(resolved);
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+            optionsBuilder.ConfigureWarnings(w => w.Default(WarningBehavior.Throw));
+            optionsBuilder.UseSqlite("Data Source=:memory:");
+            optionsBuilder.ReplaceService<ISqlGenerationHelper, DatabricksSqlGenerationHelper>();
+            optionsBuilder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
+            return optionsBuilder;
+        }
+
+        private static string ResolveConnectionString(string? provided)
+        {
+            if (!string.IsNullOrWhiteSpace(provided))
+            {
+                return provided;
+            }
+
+            var cs = Environment.GetEnvironmentVariable("DATABRICKS_CONNECTION_STRING");
+            if (!string.IsNullOrWhiteSpace(cs))
+            {
+                return cs;
+            }
+
+            var dsn = Environment.GetEnvironmentVariable("DATABRICKS_DSN");
+            if (!string.IsNullOrWhiteSpace(dsn))
+            {
+                var token = Environment.GetEnvironmentVariable("DATABRICKS_TOKEN");
+                if (string.IsNullOrWhiteSpace(token))
+                {
+                    throw new InvalidOperationException("Databricks token not provided via connection string or DATABRICKS_TOKEN.");
+                }
+
+                return $"DSN={dsn};UID=token;PWD={token}";
+            }
+
+            throw new InvalidOperationException("No Databricks connection information found.");
+        }
+    }
+}

--- a/src/EFCore.Databricks/Infrastructure/DatabricksOptionsExtension.cs
+++ b/src/EFCore.Databricks/Infrastructure/DatabricksOptionsExtension.cs
@@ -1,11 +1,10 @@
-using System;
-using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.EntityFrameworkCore
+namespace EFCore.Databricks.Infrastructure
 {
     /// <summary>
     /// EF Core options extension holding Databricks specific settings.
@@ -22,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore
 
         public DatabricksOptionsExtension WithConnectionString(string connectionString)
         {
-            var clone = (DatabricksOptionsExtension)MemberwiseClone();
+            DatabricksOptionsExtension clone = (DatabricksOptionsExtension)MemberwiseClone();
             clone.ConnectionString = connectionString;
             return clone;
         }
@@ -39,12 +38,6 @@ namespace Microsoft.EntityFrameworkCore
             services.AddSingleton<IParameterNameGeneratorFactory, SequentialParameterNameGeneratorFactory>();
             services.AddSingleton<IDatabaseProvider, DatabaseProvider<DatabricksOptionsExtension>>();
 
-            var initializerInterface = Type.GetType("Microsoft.EntityFrameworkCore.Internal.ISingletonOptionsInitializer, Microsoft.EntityFrameworkCore");
-            var initializerImplementation = Type.GetType("Microsoft.EntityFrameworkCore.Internal.SingletonOptionsInitializer, Microsoft.EntityFrameworkCore");
-            if (initializerInterface != null && initializerImplementation != null)
-            {
-                services.AddSingleton(initializerInterface, initializerImplementation);
-            }
         }
 
         public void Validate(IDbContextOptions options)

--- a/src/EFCore.Databricks/Infrastructure/DatabricksOptionsExtension.cs
+++ b/src/EFCore.Databricks/Infrastructure/DatabricksOptionsExtension.cs
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore
                 _extension = extension;
             }
 
-            public override bool IsDatabaseProvider => false;
+            public override bool IsDatabaseProvider => true;
             public override string LogFragment => "";
             public override int GetServiceProviderHashCode() => 0;
             public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other) => true;

--- a/src/EFCore.Databricks/Infrastructure/DatabricksOptionsExtension.cs
+++ b/src/EFCore.Databricks/Infrastructure/DatabricksOptionsExtension.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -27,13 +29,30 @@ namespace Microsoft.EntityFrameworkCore
 
         public void ApplyServices(IServiceCollection services)
         {
+            new EntityFrameworkRelationalServicesBuilder(services).TryAddCoreServices();
+
             services.AddSingleton<IDbContextOptionsExtension, DatabricksOptionsExtension>();
             services.AddSingleton<ISqlGenerationHelper, DatabricksSqlGenerationHelper>();
+            services.AddSingleton<ITypeMappingSource, DatabricksTypeMappingSource>();
+            services.AddScoped<IRelationalConnection, DatabricksRelationalConnection>();
+            services.AddSingleton<IQuerySqlGeneratorFactory, DatabricksQuerySqlGeneratorFactory>();
+            services.AddSingleton<IParameterNameGeneratorFactory, SequentialParameterNameGeneratorFactory>();
+            services.AddSingleton<IDatabaseProvider, DatabaseProvider<DatabricksOptionsExtension>>();
+
+            var initializerInterface = Type.GetType("Microsoft.EntityFrameworkCore.Internal.ISingletonOptionsInitializer, Microsoft.EntityFrameworkCore");
+            var initializerImplementation = Type.GetType("Microsoft.EntityFrameworkCore.Internal.SingletonOptionsInitializer, Microsoft.EntityFrameworkCore");
+            if (initializerInterface != null && initializerImplementation != null)
+            {
+                services.AddSingleton(initializerInterface, initializerImplementation);
+            }
         }
 
         public void Validate(IDbContextOptions options)
         {
-            // nothing yet
+            if (string.IsNullOrWhiteSpace(ConnectionString))
+            {
+                throw new InvalidOperationException("A valid connection string must be provided.");
+            }
         }
 
         public DbContextOptionsExtensionInfo Info => _info ??= new ExtensionInfo(this);
@@ -48,9 +67,10 @@ namespace Microsoft.EntityFrameworkCore
             }
 
             public override bool IsDatabaseProvider => true;
-            public override string LogFragment => "";
-            public override int GetServiceProviderHashCode() => 0;
-            public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other) => true;
+            public override string LogFragment => $"Databricks " + (string.IsNullOrEmpty(_extension.ConnectionString) ? string.Empty : "ConnectionString");
+            public override int GetServiceProviderHashCode() => _extension.ConnectionString?.GetHashCode() ?? 0;
+            public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
+                => other is ExtensionInfo otherInfo && _extension.ConnectionString == otherInfo._extension.ConnectionString;
             public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
             {
                 debugInfo["Databricks:ConnectionString"] = _extension.ConnectionString ?? "";

--- a/src/EFCore.Databricks/Infrastructure/DatabricksOptionsExtension.cs
+++ b/src/EFCore.Databricks/Infrastructure/DatabricksOptionsExtension.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// EF Core options extension holding Databricks specific settings.
+    /// </summary>
+    public sealed class DatabricksOptionsExtension : IDbContextOptionsExtension
+    {
+        private DbContextOptionsExtensionInfo? _info;
+
+        public string? ConnectionString { get; private set; }
+
+        public DatabricksOptionsExtension()
+        {
+        }
+
+        public DatabricksOptionsExtension WithConnectionString(string connectionString)
+        {
+            var clone = (DatabricksOptionsExtension)MemberwiseClone();
+            clone.ConnectionString = connectionString;
+            return clone;
+        }
+
+        public void ApplyServices(IServiceCollection services)
+        {
+            services.AddSingleton<IDbContextOptionsExtension, DatabricksOptionsExtension>();
+            services.AddSingleton<ISqlGenerationHelper, DatabricksSqlGenerationHelper>();
+        }
+
+        public void Validate(IDbContextOptions options)
+        {
+            // nothing yet
+        }
+
+        public DbContextOptionsExtensionInfo Info => _info ??= new ExtensionInfo(this);
+
+        private sealed class ExtensionInfo : DbContextOptionsExtensionInfo
+        {
+            private readonly DatabricksOptionsExtension _extension;
+
+            public ExtensionInfo(DatabricksOptionsExtension extension) : base(extension)
+            {
+                _extension = extension;
+            }
+
+            public override bool IsDatabaseProvider => false;
+            public override string LogFragment => "";
+            public override int GetServiceProviderHashCode() => 0;
+            public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other) => true;
+            public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+            {
+                debugInfo["Databricks:ConnectionString"] = _extension.ConnectionString ?? "";
+            }
+        }
+    }
+}

--- a/src/EFCore.Databricks/Infrastructure/DatabricksQuerySqlGenerator.cs
+++ b/src/EFCore.Databricks/Infrastructure/DatabricksQuerySqlGenerator.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// Generates Databricks compatible SQL queries.
+    /// </summary>
+    public sealed class DatabricksQuerySqlGenerator : QuerySqlGenerator
+    {
+        public DatabricksQuerySqlGenerator(QuerySqlGeneratorDependencies dependencies)
+            : base(dependencies)
+        {
+        }
+
+        protected override void GenerateLimitOffset(SelectExpression selectExpression)
+        {
+            if (selectExpression.Offset != null)
+            {
+                throw new NotSupportedException("Not implemented for now (read-only provider)");
+            }
+
+            if (selectExpression.Limit != null)
+            {
+                Sql.AppendLine().Append("LIMIT ");
+                Visit(selectExpression.Limit);
+            }
+        }
+    }
+}

--- a/src/EFCore.Databricks/Infrastructure/DatabricksQuerySqlGenerator.cs
+++ b/src/EFCore.Databricks/Infrastructure/DatabricksQuerySqlGenerator.cs
@@ -1,8 +1,7 @@
-using System;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
-namespace Microsoft.EntityFrameworkCore
+namespace EFCore.Databricks.Infrastructure
 {
     /// <summary>
     /// Generates Databricks compatible SQL queries.
@@ -18,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             if (selectExpression.Offset != null)
             {
-                throw new NotSupportedException("Not implemented for now (read-only provider)");
+                throw new NotSupportedException("OFFSET clause is not supported by the Databricks provider");
             }
 
             if (selectExpression.Limit != null)

--- a/src/EFCore.Databricks/Infrastructure/DatabricksQuerySqlGeneratorFactory.cs
+++ b/src/EFCore.Databricks/Infrastructure/DatabricksQuerySqlGeneratorFactory.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// Creates instances of <see cref="DatabricksQuerySqlGenerator"/>.
+    /// </summary>
+    public sealed class DatabricksQuerySqlGeneratorFactory : IQuerySqlGeneratorFactory
+    {
+        private readonly QuerySqlGeneratorDependencies _dependencies;
+
+        public DatabricksQuerySqlGeneratorFactory(QuerySqlGeneratorDependencies dependencies)
+        {
+            _dependencies = dependencies;
+        }
+
+        public QuerySqlGenerator Create() => new DatabricksQuerySqlGenerator(_dependencies);
+    }
+}

--- a/src/EFCore.Databricks/Infrastructure/DatabricksQuerySqlGeneratorFactory.cs
+++ b/src/EFCore.Databricks/Infrastructure/DatabricksQuerySqlGeneratorFactory.cs
@@ -1,3 +1,4 @@
+using EFCore.Databricks.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
 
 namespace Microsoft.EntityFrameworkCore

--- a/src/EFCore.Databricks/Infrastructure/DatabricksRelationalConnection.cs
+++ b/src/EFCore.Databricks/Infrastructure/DatabricksRelationalConnection.cs
@@ -1,0 +1,20 @@
+using System.Data.Common;
+using System.Data.Odbc;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// Provides a relational connection for Databricks using ODBC.
+    /// </summary>
+    public sealed class DatabricksRelationalConnection : RelationalConnection
+    {
+        public DatabricksRelationalConnection(RelationalConnectionDependencies dependencies)
+            : base(dependencies)
+        {
+        }
+
+        protected override DbConnection CreateDbConnection()
+            => new OdbcConnection(ConnectionString);
+    }
+}

--- a/src/EFCore.Databricks/Infrastructure/DatabricksSqlGenerationHelper.cs
+++ b/src/EFCore.Databricks/Infrastructure/DatabricksSqlGenerationHelper.cs
@@ -12,7 +12,10 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
+        public override string GenerateParameterName(string name)
+            => name;
+
         public override string GenerateParameterNamePlaceholder(string name)
-            => "?";
+            => $"?{name}";
     }
 }

--- a/src/EFCore.Databricks/Infrastructure/DatabricksSqlGenerationHelper.cs
+++ b/src/EFCore.Databricks/Infrastructure/DatabricksSqlGenerationHelper.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// Generates Databricks compatible SQL fragments.
+    /// </summary>
+    public sealed class DatabricksSqlGenerationHelper : RelationalSqlGenerationHelper
+    {
+        public DatabricksSqlGenerationHelper(RelationalSqlGenerationHelperDependencies dependencies)
+            : base(dependencies)
+        {
+        }
+
+        public override string GenerateParameterNamePlaceholder(string name)
+            => "?";
+    }
+}

--- a/src/EFCore.Databricks/Infrastructure/DatabricksTypeMappingSource.cs
+++ b/src/EFCore.Databricks/Infrastructure/DatabricksTypeMappingSource.cs
@@ -1,0 +1,48 @@
+using System;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// Provides type mappings for Databricks SQL.
+    /// </summary>
+    public sealed class DatabricksTypeMappingSource : RelationalTypeMappingSource
+    {
+        private static readonly BoolTypeMapping _bool = new("BOOLEAN");
+        private static readonly IntTypeMapping _int = new("INTEGER");
+        private static readonly LongTypeMapping _long = new("BIGINT");
+        private static readonly DoubleTypeMapping _double = new("DOUBLE");
+        private static readonly DecimalTypeMapping _decimal = new("DECIMAL(38,18)");
+        private static readonly StringTypeMapping _string = new("STRING", System.Data.DbType.String, unicode: true, size: null);
+        private static readonly ByteArrayTypeMapping _binary = new("BINARY");
+        private static readonly DateTimeTypeMapping _dateTime = new("TIMESTAMP");
+        private static readonly DateTimeOffsetTypeMapping _dateTimeOffset = new("TIMESTAMP");
+        private static readonly GuidTypeMapping _guid = new("STRING");
+
+        public DatabricksTypeMappingSource(TypeMappingSourceDependencies dependencies, RelationalTypeMappingSourceDependencies relational)
+            : base(dependencies, relational)
+        {
+        }
+
+        protected override RelationalTypeMapping? FindMapping(in RelationalTypeMappingInfo mappingInfo)
+        {
+            var clrType = mappingInfo.ClrType;
+            if (clrType != null && Nullable.GetUnderlyingType(clrType) != null)
+            {
+                clrType = Nullable.GetUnderlyingType(clrType)!;
+            }
+            if (clrType == typeof(string)) return _string;
+            if (clrType == typeof(int)) return _int;
+            if (clrType == typeof(long)) return _long;
+            if (clrType == typeof(bool)) return _bool;
+            if (clrType == typeof(double) || clrType == typeof(float)) return _double;
+            if (clrType == typeof(decimal)) return _decimal;
+            if (clrType == typeof(DateTime)) return _dateTime;
+            if (clrType == typeof(DateTimeOffset)) return _dateTimeOffset;
+            if (clrType == typeof(Guid)) return _guid;
+            if (clrType == typeof(byte[])) return _binary;
+
+            return base.FindMapping(mappingInfo);
+        }
+    }
+}

--- a/src/EFCore.Databricks/Infrastructure/SequentialParameterNameGenerator.cs
+++ b/src/EFCore.Databricks/Infrastructure/SequentialParameterNameGenerator.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// Generates sequential parameter names in the form <c>__p_n</c>.
+    /// </summary>
+    public sealed class SequentialParameterNameGeneratorFactory : IParameterNameGeneratorFactory
+    {
+        public ParameterNameGenerator Create() => new SequentialParameterNameGenerator();
+
+        private sealed class SequentialParameterNameGenerator : ParameterNameGenerator
+        {
+            private int _count;
+
+            public override string GenerateNext() => $"__p_{_count++}";
+
+            public override void Reset() => _count = 0;
+        }
+    }
+}

--- a/src/EFCore.Databricks/Infrastructure/SequentialParameterNameGenerator.cs
+++ b/src/EFCore.Databricks/Infrastructure/SequentialParameterNameGenerator.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
-    /// Generates sequential parameter names in the form <c>__p_n</c>.
+    /// Generates sequential parameter names in the form <c>__p_0</c>, <c>__p_1</c>, etc.
     /// </summary>
     public sealed class SequentialParameterNameGeneratorFactory : IParameterNameGeneratorFactory
     {

--- a/tests/EFCore.Databricks.Tests/Contract/InnerJoinTests.cs
+++ b/tests/EFCore.Databricks.Tests/Contract/InnerJoinTests.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace EFCore.Databricks.Tests.Contract
+{
+    public class InnerJoinTests
+    {
+        private class TestContext : DbContext
+        {
+            public DbSet<Customer> Customers => Set<Customer>();
+            public DbSet<Order> Orders => Set<Order>();
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
+                => options.UseDatabricks("Data Source=:memory:");
+        }
+
+        private record Customer(int Id, string Name);
+        private record Order(int Id, int CustomerId);
+
+        [Fact]
+        public void Translates_inner_join()
+        {
+            using var ctx = new TestContext();
+            var sql = ctx.Customers
+                .Join(ctx.Orders, c => c.Id, o => o.CustomerId, (c, o) => new { c.Name, o.Id })
+                .ToQueryString();
+
+            Assert.Contains("INNER JOIN", sql.ToUpperInvariant());
+        }
+    }
+}

--- a/tests/EFCore.Databricks.Tests/Contract/QuickstartScenarioTests.cs
+++ b/tests/EFCore.Databricks.Tests/Contract/QuickstartScenarioTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace EFCore.Databricks.Tests.Contract
+{
+    public class QuickstartScenarioTests
+    {
+        private class TestContext : DbContext
+        {
+            public DbSet<Customer> Customers => Set<Customer>();
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
+                => options.UseDatabricks();
+        }
+
+        private record Customer(int Id, string Name);
+
+        [Fact]
+        public void Configures_via_environment_variables()
+        {
+            Environment.SetEnvironmentVariable("DATABRICKS_CONNECTION_STRING", "Data Source=:memory:");
+            using var ctx = new TestContext();
+
+            Assert.Equal(QueryTrackingBehavior.NoTracking, ctx.ChangeTracker.QueryTrackingBehavior);
+
+            var sql = ctx.Customers.OrderBy(c => c.Id).Take(1).ToQueryString();
+            Assert.Contains("LIMIT", sql.ToUpperInvariant());
+        }
+    }
+}

--- a/tests/EFCore.Databricks.Tests/Contract/QuickstartScenarioTests.cs
+++ b/tests/EFCore.Databricks.Tests/Contract/QuickstartScenarioTests.cs
@@ -19,13 +19,21 @@ namespace EFCore.Databricks.Tests.Contract
         [Fact]
         public void Configures_via_environment_variables()
         {
+            var original = Environment.GetEnvironmentVariable("DATABRICKS_CONNECTION_STRING");
             Environment.SetEnvironmentVariable("DATABRICKS_CONNECTION_STRING", "Data Source=:memory:");
-            using var ctx = new TestContext();
+            try
+            {
+                using var ctx = new TestContext();
 
-            Assert.Equal(QueryTrackingBehavior.NoTracking, ctx.ChangeTracker.QueryTrackingBehavior);
+                Assert.Equal(QueryTrackingBehavior.NoTracking, ctx.ChangeTracker.QueryTrackingBehavior);
 
-            var sql = ctx.Customers.OrderBy(c => c.Id).Take(1).ToQueryString();
-            Assert.Contains("LIMIT", sql.ToUpperInvariant());
+                var sql = ctx.Customers.OrderBy(c => c.Id).Take(1).ToQueryString();
+                Assert.Contains("LIMIT", sql.ToUpperInvariant());
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("DATABRICKS_CONNECTION_STRING", original);
+            }
         }
     }
 }

--- a/tests/EFCore.Databricks.Tests/Contract/SelectGroupByAggregateTests.cs
+++ b/tests/EFCore.Databricks.Tests/Contract/SelectGroupByAggregateTests.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace EFCore.Databricks.Tests.Contract
+{
+    public class SelectGroupByAggregateTests
+    {
+        private class TestContext : DbContext
+        {
+            public DbSet<Order> Orders => Set<Order>();
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
+                => options.UseDatabricks("Data Source=:memory:");
+        }
+
+        private record Order(int Id, int CustomerId);
+
+        [Fact]
+        public void Translates_group_by_with_count()
+        {
+            using var ctx = new TestContext();
+            var sql = ctx.Orders
+                .GroupBy(o => o.CustomerId)
+                .Select(g => new { g.Key, Count = g.Count() })
+                .ToQueryString();
+
+            var upper = sql.ToUpperInvariant();
+            Assert.Contains("GROUP BY", upper);
+            Assert.Contains("COUNT", upper);
+        }
+    }
+}

--- a/tests/EFCore.Databricks.Tests/Contract/SelectOrderByLimitTests.cs
+++ b/tests/EFCore.Databricks.Tests/Contract/SelectOrderByLimitTests.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace EFCore.Databricks.Tests.Contract
+{
+    public class SelectOrderByLimitTests
+    {
+        private class TestContext : DbContext
+        {
+            public DbSet<Customer> Customers => Set<Customer>();
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
+                => options.UseDatabricks("Data Source=:memory:");
+        }
+
+        private record Customer(int Id, string Name);
+
+        [Fact]
+        public void Translates_order_by_and_limit()
+        {
+            using var ctx = new TestContext();
+            var sql = ctx.Customers
+                .OrderBy(c => c.Name)
+                .Take(3)
+                .ToQueryString();
+
+            var upper = sql.ToUpperInvariant();
+            Assert.Contains("ORDER BY", upper);
+            Assert.Contains("LIMIT", upper);
+        }
+    }
+}

--- a/tests/EFCore.Databricks.Tests/Contract/SelectProjectionTests.cs
+++ b/tests/EFCore.Databricks.Tests/Contract/SelectProjectionTests.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace EFCore.Databricks.Tests.Contract
+{
+    public class SelectProjectionTests
+    {
+        private class TestContext : DbContext
+        {
+            public DbSet<Customer> Customers => Set<Customer>();
+
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
+                => options.UseDatabricks("Data Source=:memory:");
+        }
+
+        private record Customer(int Id, string Name);
+
+        [Fact]
+        public void Generates_select_projection_sql()
+        {
+            using var ctx = new TestContext();
+            var sql = ctx.Customers
+                .Select(c => c.Name)
+                .OrderBy(c => c)
+                .Take(5)
+                .ToQueryString();
+
+            Assert.Contains("LIMIT", sql.ToUpperInvariant());
+        }
+    }
+}

--- a/tests/EFCore.Databricks.Tests/Contract/SelectWhereTests.cs
+++ b/tests/EFCore.Databricks.Tests/Contract/SelectWhereTests.cs
@@ -26,8 +26,8 @@ namespace EFCore.Databricks.Tests.Contract
                 .ToQueryString();
 
             Assert.Contains("WHERE", sql.ToUpperInvariant());
-            Assert.Contains("@__id_0", sql);
-            Assert.Contains("@__name_1", sql);
+            Assert.Contains("?__id_0", sql);
+            Assert.Contains("?__name_1", sql);
         }
     }
 }

--- a/tests/EFCore.Databricks.Tests/Contract/SelectWhereTests.cs
+++ b/tests/EFCore.Databricks.Tests/Contract/SelectWhereTests.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace EFCore.Databricks.Tests.Contract
+{
+    public class SelectWhereTests
+    {
+        private class TestContext : DbContext
+        {
+            public DbSet<Customer> Customers => Set<Customer>();
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
+                => options.UseDatabricks("Data Source=:memory:");
+        }
+
+        private record Customer(int Id, string Name);
+
+        [Fact]
+        public void Translates_where_clause_with_parameters()
+        {
+            using var ctx = new TestContext();
+            var id = 10;
+            var name = "foo";
+            var sql = ctx.Customers
+                .Where(c => c.Id > id && c.Name == name)
+                .ToQueryString();
+
+            Assert.Contains("WHERE", sql.ToUpperInvariant());
+            Assert.Contains("@__id_0", sql);
+            Assert.Contains("@__name_1", sql);
+        }
+    }
+}

--- a/tests/EFCore.Databricks.Tests/EFCore.Databricks.Tests.csproj
+++ b/tests/EFCore.Databricks.Tests/EFCore.Databricks.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="FakeItEasy" Version="8.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EFCore.Databricks\EFCore.Databricks.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add `UseDatabricks` extension with environment variable precedence and no-tracking default
- introduce basic SQL helper and options extension
- expand contract tests for select, filter, grouping, ordering, join, and quickstart scenario

## Testing
- `dotnet test EFCore.Databricks.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68bace908bf88327b7d15e5f8d5aa55f